### PR TITLE
Improve: logs: add the task-name log

### DIFF
--- a/service/aria2.go
+++ b/service/aria2.go
@@ -150,7 +150,7 @@ func (aria2Service *Aria2Service) CheckAndRestoreSuspendingStatus(aria2Client *c
 		}
 
 		if onChainStatus == nil {
-			logs.GetLogger().Info("no on chain status for deal%", deal.DealCid)
+			logs.GetLogger().Info("no on chain status for deal%", *deal.TaskName+":"+deal.DealCid)
 			continue
 		}
 
@@ -224,7 +224,7 @@ func (aria2Service *Aria2Service) StartDownload(aria2Client *client.Aria2Client,
 		}
 
 		if onChainStatus == nil {
-			logs.GetLogger().Info("not found the deal on the chain", deal2Download.DealCid)
+			logs.GetLogger().Info("not found the deal on the chain", *deal2Download.TaskName+":"+deal2Download.DealCid)
 			UpdateStatusAndLog(deal2Download, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
 			continue
 		} else if *onChainStatus == ONCHAIN_DEAL_STATUS_WAITTING {

--- a/service/common.go
+++ b/service/common.go
@@ -264,7 +264,7 @@ func UpdateStatusAndLog(deal *libmodel.OfflineDeal, newSwanStatus string, messag
 
 func GetLog(deal *libmodel.OfflineDeal, messages ...string) string {
 	text := GetNote(messages...)
-	msg := fmt.Sprintf("deal(id=%d):%s,%s", deal.Id, deal.DealCid, text)
+	msg := fmt.Sprintf("deal(id=%d):%s,%s", deal.Id, *deal.TaskName+":"+deal.DealCid, text)
 	return msg
 }
 


### PR DESCRIPTION
In the logs, `task-name` can always be found before the `dealCID(proposalCID) `.