### PR TITLE
New: aria2: delete the useless car file automatically

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,10 +25,11 @@ type lotus struct {
 }
 
 type aria2 struct {
-	Aria2DownloadDir string `toml:"aria2_download_dir"`
-	Aria2Host        string `toml:"aria2_host"`
-	Aria2Port        int    `toml:"aria2_port"`
-	Aria2Secret      string `toml:"aria2_secret"`
+	Aria2DownloadDir       string `toml:"aria2_download_dir"`
+	Aria2Host              string `toml:"aria2_host"`
+	Aria2Port              int    `toml:"aria2_port"`
+	Aria2Secret            string `toml:"aria2_secret"`
+	Aria2AutoDeleteCarFile bool   `toml:"aria2_auto_delete_car_file"`
 }
 
 type main struct {

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -8,9 +8,10 @@ market_access_token=""                       # Access token of lotus market web 
 
 [aria2]
 aria2_download_dir = "%%ARIA2_DOWNLOAD_DIR%%"   # Directory where offline deal files will be downloaded for importing
-aria2_host = "127.0.0.1"  # Aria2 server address
-aria2_port = 6800         # Aria2 server port
-aria2_secret = "my_aria2_secret"  # Must be the same value as rpc-secure in aria2.conf
+aria2_host = "127.0.0.1"                        # Aria2 server address
+aria2_port = 6800                               # Aria2 server port
+aria2_secret = "my_aria2_secret"                # Must be the same value as rpc-secure in aria2.conf
+aria2_auto_delete_car_file= true                # After the deal becomes Active or Error, the CAR file will be deleted automatically
 
 [main]
 api_url = "https://go-swan-server.filswan.com"  # Swan API address. For Swan production, it is "https://go-swan-server.filswan.com"


### PR DESCRIPTION
- Add the new feature `aria2_auto_delete_car_file` in the config file `[aria2].aria2_auto_delete_car_file=true`
- Once the deal is Active or Error, the CAR file will be deleted automatically from SP's local storage