### PR TITLE
Fix: Skip the empty deal

### DIFF
--- a/service/aria2.go
+++ b/service/aria2.go
@@ -149,7 +149,8 @@ func (aria2Service *Aria2Service) CheckAndRestoreSuspendingStatus(aria2Client *c
 		}
 
 		if onChainStatus == nil {
-			logs.GetLogger().Info("no on chain status for deal%", *deal.TaskName+":"+deal.DealCid)
+			logs.GetLogger().Info("not found the deal on the chain", *deal.TaskName+":"+deal.DealCid)
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
 			continue
 		}
 

--- a/service/lotus.go
+++ b/service/lotus.go
@@ -68,7 +68,8 @@ func (lotusService *LotusService) StartImport(swanClient *swan.SwanClient) {
 		}
 
 		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Error(GetLog(deal, "failed to get on chain status, please check if lotus miner is running properly"))
+			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
 			continue
 		}
 
@@ -140,7 +141,8 @@ func (lotusService *LotusService) StartScan(swanClient *swan.SwanClient) {
 		}
 
 		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Error(GetLog(deal, "on chain status is empty"))
+			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
 			continue
 		}
 		aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile


### PR DESCRIPTION
Update the deal to `ImportFailed` when the deal status on the chain is `nil`.