### PR TITLE
Improve: Verify the new configuration item for Aria2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"aria2", "aria2_host"},
 		{"aria2", "aria2_port"},
 		{"aria2", "aria2_secret"},
+		{"aria2", "aria2_auto_delete_car_file"},
 
 		{"main", "api_url"},
 		{"main", "miner_fid"},


### PR DESCRIPTION
`[aria2]. aria2_auto_delete_car_file` is required.