### PR TITLE
New: Aira2: Config for parallel download counts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,12 @@ type lotus struct {
 }
 
 type aria2 struct {
-	Aria2DownloadDir       string `toml:"aria2_download_dir"`
-	Aria2Host              string `toml:"aria2_host"`
-	Aria2Port              int    `toml:"aria2_port"`
-	Aria2Secret            string `toml:"aria2_secret"`
-	Aria2AutoDeleteCarFile bool   `toml:"aria2_auto_delete_car_file"`
+	Aria2DownloadDir         string `toml:"aria2_download_dir"`
+	Aria2Host                string `toml:"aria2_host"`
+	Aria2Port                int    `toml:"aria2_port"`
+	Aria2Secret              string `toml:"aria2_secret"`
+	Aria2AutoDeleteCarFile   bool   `toml:"aria2_auto_delete_car_file"`
+	Aria2MaxDownloadingTasks int    `toml:"aria2_max_downloading_tasks"`
 }
 
 type main struct {
@@ -96,6 +97,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"aria2", "aria2_port"},
 		{"aria2", "aria2_secret"},
 		{"aria2", "aria2_auto_delete_car_file"},
+		{"aria2", "aria2_max_downloading_tasks"},
 
 		{"main", "api_url"},
 		{"main", "miner_fid"},

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -12,6 +12,7 @@ aria2_host = "127.0.0.1"                        # Aria2 server address
 aria2_port = 6800                               # Aria2 server port
 aria2_secret = "my_aria2_secret"                # Must be the same value as rpc-secure in aria2.conf
 aria2_auto_delete_car_file= true                # After the deal becomes Active or Error, the CAR file will be deleted automatically
+aria2_max_downloading_tasks = 10                # Aria2 max downloading tasks. default: 10
 
 [main]
 api_url = "https://go-swan-server.filswan.com"  # Swan API address. For Swan production, it is "https://go-swan-server.filswan.com"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
-	github.com/filswan/go-swan-lib v0.2.116
+	github.com/filswan/go-swan-lib splib
 	github.com/gin-gonic/gin v1.7.4
 	github.com/itsjamie/gin-cors v0.0.0-20160420130702-97b4a9da7933
 	github.com/joho/godotenv v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
-	github.com/filswan/go-swan-lib splib
+	github.com/filswan/go-swan-lib v0.2.117-0.20220916065530-67e102eda340
 	github.com/gin-gonic/gin v1.7.4
 	github.com/itsjamie/gin-cors v0.0.0-20160420130702-97b4a9da7933
 	github.com/joho/godotenv v1.4.0

--- a/service/aria2.go
+++ b/service/aria2.go
@@ -212,13 +212,16 @@ func (aria2Service *Aria2Service) StartDownload4Deal(deal *libmodel.OfflineDeal,
 
 func (aria2Service *Aria2Service) StartDownload(aria2Client *client.Aria2Client, swanClient *swan.SwanClient) {
 	downloadingDeals := GetOfflineDeals(swanClient, DEAL_STATUS_DOWNLOADING, aria2Service.MinerFid, nil)
-
 	countDownloadingDeals := len(downloadingDeals)
-	if countDownloadingDeals >= ARIA2_MAX_DOWNLOADING_TASKS {
+	aria2MaxDownloadingTasks := config.GetConfig().Aria2.Aria2MaxDownloadingTasks
+	if aria2MaxDownloadingTasks <= 0 {
+		logs.GetLogger().Warning("config [aria2].aria2_max_downloading_tasks is " + strconv.Itoa(aria2MaxDownloadingTasks) + ", no CAR file will be downloaded")
+	}
+	if countDownloadingDeals >= aria2MaxDownloadingTasks {
 		return
 	}
 
-	for i := 1; i <= ARIA2_MAX_DOWNLOADING_TASKS-countDownloadingDeals; i++ {
+	for i := 1; i <= aria2MaxDownloadingTasks-countDownloadingDeals; i++ {
 		deal2Download := aria2Service.FindNextDealReady2Download(swanClient)
 		if deal2Download == nil {
 			logs.GetLogger().Info("No offline deal to download")

--- a/service/aria2.go
+++ b/service/aria2.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"swan-provider/common/constants"
 	"swan-provider/config"
@@ -150,7 +151,7 @@ func (aria2Service *Aria2Service) CheckAndRestoreSuspendingStatus(aria2Client *c
 	suspendingDeals := GetOfflineDeals(swanClient, DEAL_STATUS_SUSPENDING, aria2Service.MinerFid, nil)
 
 	for _, deal := range suspendingDeals {
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
+		_, _, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			continue
@@ -229,7 +230,7 @@ func (aria2Service *Aria2Service) StartDownload(aria2Client *client.Aria2Client,
 		}
 
 		//logs.GetLogger().Info("deal:", deal2Download.Id, " ", deal2Download.DealCid, deal2Download)
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal2Download.DealCid)
+		_, _, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal2Download.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			break

--- a/service/common.go
+++ b/service/common.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"swan-provider/common/constants"
 	"swan-provider/config"
@@ -44,7 +45,6 @@ const ONCHAIN_DEAL_STATUS_ACCEPT = "StorageDealAcceptWait"
 const ONCHAIN_DEAL_STATUS_SEALING = "StorageDealSealing"
 const ONCHAIN_DEAL_STATUS_AWAITING = "StorageDealAwaitingPreCommit"
 
-const ARIA2_MAX_DOWNLOADING_TASKS = 10
 const LOTUS_IMPORT_NUMNBER = 20 //Max number of deals to be imported at a time
 const LOTUS_SCAN_NUMBER = 100   //Max number of deals to be scanned at a time
 

--- a/service/lotus.go
+++ b/service/lotus.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"fmt"
+	"github.com/filswan/go-swan-lib/model"
 	"os"
 	"swan-provider/config"
 	"time"
@@ -60,53 +60,14 @@ func (lotusService *LotusService) StartImport(swanClient *swan.SwanClient) {
 		return
 	}
 
+	aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
 	for _, deal := range deals {
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
+		minerId, dealId, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			return
 		}
-
-		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
-			continue
-		}
-
-		logs.GetLogger().Info(GetLog(deal, *onChainStatus, *onChainMessage))
-
-		switch *onChainStatus {
-		case ONCHAIN_DEAL_STATUS_ERROR:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal is error before importing", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_ACTIVE:
-			UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal is active before importing", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_ACCEPT:
-			UpdateStatusAndLog(deal, deal.Status, "deal will be ready shortly", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_NOTFOUND:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal not found", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_WAITTING:
-			currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
-			if err != nil {
-				logs.GetLogger().Error(err)
-				return
-			}
-
-			if int64(deal.StartEpoch)-*currentEpoch < int64(lotusService.ExpectedSealingTime) {
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal expired before importing", *onChainStatus, *onChainMessage)
-				continue
-			}
-
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTING, "importing deal")
-
-			err = lotusService.LotusMarket.LotusImportData(deal.DealCid, deal.FilePath)
-			if err != nil { //There should be no output if everything goes well
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "import deal failed", err.Error())
-				continue
-			}
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal imported")
-		default:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal already imported", *onChainStatus, *onChainMessage)
-		}
+		UpdateSwanDealStatus(minerId, dealId, onChainStatus, *onChainMessage, deal, true, aria2AutoDeleteCarFile)
 
 		logs.GetLogger().Info("Sleeping...")
 		time.Sleep(lotusService.ImportIntervalSecond)
@@ -131,51 +92,15 @@ func (lotusService *LotusService) StartScan(swanClient *swan.SwanClient) {
 		logs.GetLogger().Error("no deals returned from lotus")
 		return
 	}
-
+	aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
 	for _, deal := range deals {
-		//logs.GetLogger().Info(GetLog(deal, "current status in swan:"+deal.Status, "current note in swan:"+deal.Note))
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatusFromDeals(lotusDeals, deal.DealCid)
+		minerId, dealId, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatusFromDeals(lotusDeals, deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(GetLog(deal, err.Error()))
 			return
 		}
 
-		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
-			continue
-		}
-		aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
-		switch *onChainStatus {
-		case ONCHAIN_DEAL_STATUS_ERROR:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal error when scan", *onChainStatus, *onChainMessage)
-			if aria2AutoDeleteCarFile {
-				msg := fmt.Sprintf("deal(id=%d):%s, %s, %s", deal.Id, *deal.TaskName+":"+deal.DealCid+" has been "+*onChainStatus, "delete the car file", deal.FilePath)
-				logs.GetLogger().Info(msg)
-				DeleteDownloadedFiles(deal.FilePath)
-			}
-		case ONCHAIN_DEAL_STATUS_ACTIVE:
-			UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal has been completed", *onChainStatus, *onChainMessage)
-			if aria2AutoDeleteCarFile {
-				msg := fmt.Sprintf("deal(id=%d):%s, %s, %s", deal.Id, *deal.TaskName+":"+deal.DealCid+" has been "+*onChainStatus, "delete the car file", deal.FilePath)
-				logs.GetLogger().Info(msg)
-				DeleteDownloadedFiles(deal.FilePath)
-			}
-		case ONCHAIN_DEAL_STATUS_AWAITING, ONCHAIN_DEAL_STATUS_SEALING:
-			currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
-			if err != nil {
-				logs.GetLogger().Error(GetLog(deal, err.Error()))
-				return
-			}
-
-			if *currentEpoch > int64(deal.StartEpoch) {
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "sector is proved and active, on chain status bug", *onChainStatus, *onChainMessage)
-			} else {
-				UpdateStatusAndLog(deal, deal.Status, *onChainStatus, *onChainMessage)
-			}
-		default:
-			UpdateStatusAndLog(deal, deal.Status, *onChainStatus, *onChainMessage)
-		}
+		UpdateSwanDealStatus(minerId, dealId, onChainStatus, *onChainMessage, deal, false, aria2AutoDeleteCarFile)
 	}
 }
 
@@ -195,5 +120,89 @@ func DeleteDownloadedFiles(filePath string) {
 				logs.GetLogger().Info("delete file successfully ", " file path ", filePath)
 			}
 		}
+	}
+}
+
+func CorrectDealStatus(startEpoch int, minerId string, dealId uint64, onChainStatus string) (*string, error) {
+	dealInfo, err := lotusService.LotusClient.LotusGetDealById(dealId)
+	if err != nil {
+		logs.GetLogger().Errorf("get market deal info by dealId failed,dealId: %d,error: %s ", dealId, err.Error())
+		return nil, err
+	}
+	if dealInfo.State.SectorStartEpoch > -1 && dealInfo.State.SlashEpoch == -1 && dealInfo.Proposal.Provider == minerId {
+		onChainStatus = "StorageDealActive"
+	}
+
+	currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
+	if err != nil {
+		logs.GetLogger().Error(err)
+		return nil, err
+	}
+	if startEpoch < int(*currentEpoch)+lotusService.ExpectedSealingTime {
+		onChainStatus = "StorageDealError"
+	}
+	return &onChainStatus, nil
+}
+
+func UpdateSwanDealStatus(minerId string, dealId uint64, onChainStatus *string, onChainMessage string, deal *model.OfflineDeal, isImport, aria2AutoDeleteCarFile bool) {
+	if dealId > 0 {
+		status, err := CorrectDealStatus(deal.StartEpoch, minerId, dealId, *onChainStatus)
+		if err != nil {
+			logs.GetLogger().Error(GetLog(deal, err.Error()))
+			return
+		}
+		onChainStatus = status
+	}
+
+	if utils.IsStrEmpty(onChainStatus) {
+		logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
+		return
+	}
+
+	switch *onChainStatus {
+	case ONCHAIN_DEAL_STATUS_ERROR:
+		if isImport {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal is error before importing", *onChainStatus, onChainMessage)
+		} else {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal error when scan", *onChainStatus, onChainMessage)
+			if aria2AutoDeleteCarFile {
+				logs.GetLogger().Infof("dealId:%d, taskName:%s, dealCid:%s, has been %s, delete the car file, filePath:%s", dealId, *deal.TaskName, deal.DealCid, *onChainStatus, deal.FilePath)
+				DeleteDownloadedFiles(deal.FilePath)
+			}
+		}
+	case ONCHAIN_DEAL_STATUS_ACTIVE:
+		UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal has been completed", *onChainStatus, onChainMessage)
+		if aria2AutoDeleteCarFile {
+			logs.GetLogger().Infof("dealId:%d, taskName:%s, dealCid:%s, has been %s, delete the car file, filePath:%s", dealId, *deal.TaskName, deal.DealCid, *onChainStatus, deal.FilePath)
+			DeleteDownloadedFiles(deal.FilePath)
+		}
+	case ONCHAIN_DEAL_STATUS_ACCEPT:
+		UpdateStatusAndLog(deal, deal.Status, "deal will be ready shortly", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_NOTFOUND:
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal not found", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_AWAITING, ONCHAIN_DEAL_STATUS_SEALING:
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal already imported", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_WAITTING:
+		currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return
+		}
+
+		if int64(deal.StartEpoch)-*currentEpoch < int64(lotusService.ExpectedSealingTime) {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal expired before importing", *onChainStatus, onChainMessage)
+			return
+		}
+
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTING, "importing deal")
+		err = lotusService.LotusMarket.LotusImportData(deal.DealCid, deal.FilePath)
+		if err != nil { //There should be no output if everything goes well
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "import deal failed", err.Error())
+			return
+		}
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal imported")
+	default:
+		UpdateStatusAndLog(deal, deal.Status, *onChainStatus, onChainMessage)
 	}
 }


### PR DESCRIPTION
Add a new feature `aria2_max_downloading_tasks` in the config file `[aria2].aria2_max_downloading_tasks=10`, which can limit the number of concurrent download tasks.