### PR TITLE
New: Aira2: Config for parallel download counts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,12 @@ type lotus struct {
 }
 
 type aria2 struct {
-	Aria2DownloadDir       string `toml:"aria2_download_dir"`
-	Aria2Host              string `toml:"aria2_host"`
-	Aria2Port              int    `toml:"aria2_port"`
-	Aria2Secret            string `toml:"aria2_secret"`
-	Aria2AutoDeleteCarFile bool   `toml:"aria2_auto_delete_car_file"`
+	Aria2DownloadDir         string `toml:"aria2_download_dir"`
+	Aria2Host                string `toml:"aria2_host"`
+	Aria2Port                int    `toml:"aria2_port"`
+	Aria2Secret              string `toml:"aria2_secret"`
+	Aria2AutoDeleteCarFile   bool   `toml:"aria2_auto_delete_car_file"`
+	Aria2MaxDownloadingTasks int    `toml:"aria2_max_downloading_tasks"`
 }
 
 type main struct {
@@ -95,6 +96,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"aria2", "aria2_host"},
 		{"aria2", "aria2_port"},
 		{"aria2", "aria2_secret"},
+		{"aria2", "aria2_max_downloading_tasks"},
 		{"aria2", "aria2_auto_delete_car_file"},
 
 		{"main", "api_url"},

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -12,6 +12,7 @@ aria2_host = "127.0.0.1"                        # Aria2 server address
 aria2_port = 6800                               # Aria2 server port
 aria2_secret = "my_aria2_secret"                # Must be the same value as rpc-secure in aria2.conf
 aria2_auto_delete_car_file= true                # After the deal becomes Active or Error, the CAR file will be deleted automatically
+aria2_max_downloading_tasks = 10                # Aria2 max downloading tasks. default: 10
 
 [main]
 api_url = "https://go-swan-server.filswan.com"  # Swan API address. For Swan production, it is "https://go-swan-server.filswan.com"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
-	github.com/filswan/go-swan-lib v0.2.116
+	github.com/filswan/go-swan-lib v0.2.117-0.20220916065530-67e102eda340
 	github.com/gin-gonic/gin v1.7.4
 	github.com/itsjamie/gin-cors v0.0.0-20160420130702-97b4a9da7933
 	github.com/joho/godotenv v1.4.0

--- a/service/common.go
+++ b/service/common.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"swan-provider/common/constants"
 	"swan-provider/config"
@@ -44,7 +45,6 @@ const ONCHAIN_DEAL_STATUS_ACCEPT = "StorageDealAcceptWait"
 const ONCHAIN_DEAL_STATUS_SEALING = "StorageDealSealing"
 const ONCHAIN_DEAL_STATUS_AWAITING = "StorageDealAwaitingPreCommit"
 
-const ARIA2_MAX_DOWNLOADING_TASKS = 10
 const LOTUS_IMPORT_NUMNBER = 20 //Max number of deals to be imported at a time
 const LOTUS_SCAN_NUMBER = 100   //Max number of deals to be scanned at a time
 
@@ -79,6 +79,7 @@ func SetAndCheckAria2Config() *client.Aria2Client {
 	aria2Host := config.GetConfig().Aria2.Aria2Host
 	aria2Port := config.GetConfig().Aria2.Aria2Port
 	aria2Secret := config.GetConfig().Aria2.Aria2Secret
+	aria2MaxDownloadingTasks := config.GetConfig().Aria2.Aria2MaxDownloadingTasks
 
 	if !utils.IsDirExists(aria2DownloadDir) {
 		err := fmt.Errorf("aria2 down load dir:%s not exits, please set config:aria2->aria2_download_dir", aria2DownloadDir)
@@ -90,7 +91,19 @@ func SetAndCheckAria2Config() *client.Aria2Client {
 	}
 
 	aria2Client = client.GetAria2Client(aria2Host, aria2Secret, aria2Port)
+	if aria2MaxDownloadingTasks <= 0 {
+		logs.GetLogger().Warning("config [aria2].aria2_max_downloading_tasks is " + strconv.Itoa(aria2MaxDownloadingTasks) + ", no CAR file will be downloaded")
+	}
+	aria2ChangeMaxConcurrentDownloads := aria2Client.ChangeMaxConcurrentDownloads(strconv.Itoa(aria2MaxDownloadingTasks))
+	if aria2ChangeMaxConcurrentDownloads == nil {
+		err := fmt.Errorf("failed to set [aria2].aria2_max_downloading_tasks, please check the Aria2 service")
+		logs.GetLogger().Fatal(err)
+	}
 
+	if aria2ChangeMaxConcurrentDownloads.Error != nil {
+		err := fmt.Errorf(aria2ChangeMaxConcurrentDownloads.Error.Message)
+		logs.GetLogger().Fatal(err)
+	}
 	return aria2Client
 }
 
@@ -264,7 +277,7 @@ func UpdateStatusAndLog(deal *libmodel.OfflineDeal, newSwanStatus string, messag
 
 func GetLog(deal *libmodel.OfflineDeal, messages ...string) string {
 	text := GetNote(messages...)
-	msg := fmt.Sprintf("deal(id=%d):%s,%s", deal.Id, *deal.TaskName+":"+deal.DealCid, text)
+	msg := fmt.Sprintf("taskName:%s, dealCid:%s, %s", *deal.TaskName, deal.DealCid, text)
 	return msg
 }
 


### PR DESCRIPTION
Add a new feature `aria2_max_downloading_tasks` in the config file `[aria2].aria2_max_downloading_tasks=10`, which can limit the number of concurrent download tasks.