### PR TITLE
Fix: Lotus: Correct the wrong deal status returned by the `lotus-miner API` using on-chain data 

### DIFF
--- a/service/aria2.go
+++ b/service/aria2.go
@@ -151,7 +151,7 @@ func (aria2Service *Aria2Service) CheckAndRestoreSuspendingStatus(aria2Client *c
 	suspendingDeals := GetOfflineDeals(swanClient, DEAL_STATUS_SUSPENDING, aria2Service.MinerFid, nil)
 
 	for _, deal := range suspendingDeals {
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
+		_, _, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			continue
@@ -230,7 +230,7 @@ func (aria2Service *Aria2Service) StartDownload(aria2Client *client.Aria2Client,
 		}
 
 		//logs.GetLogger().Info("deal:", deal2Download.Id, " ", deal2Download.DealCid, deal2Download)
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal2Download.DealCid)
+		_, _, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal2Download.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			break

--- a/service/lotus.go
+++ b/service/lotus.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"fmt"
+	"github.com/filswan/go-swan-lib/model"
 	"os"
 	"swan-provider/config"
 	"time"
@@ -60,53 +60,14 @@ func (lotusService *LotusService) StartImport(swanClient *swan.SwanClient) {
 		return
 	}
 
+	aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
 	for _, deal := range deals {
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
+		minerId, dealId, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatus(deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			return
 		}
-
-		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
-			continue
-		}
-
-		logs.GetLogger().Info(GetLog(deal, *onChainStatus, *onChainMessage))
-
-		switch *onChainStatus {
-		case ONCHAIN_DEAL_STATUS_ERROR:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal is error before importing", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_ACTIVE:
-			UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal is active before importing", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_ACCEPT:
-			UpdateStatusAndLog(deal, deal.Status, "deal will be ready shortly", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_NOTFOUND:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal not found", *onChainStatus, *onChainMessage)
-		case ONCHAIN_DEAL_STATUS_WAITTING:
-			currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
-			if err != nil {
-				logs.GetLogger().Error(err)
-				return
-			}
-
-			if int64(deal.StartEpoch)-*currentEpoch < int64(lotusService.ExpectedSealingTime) {
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal expired before importing", *onChainStatus, *onChainMessage)
-				continue
-			}
-
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTING, "importing deal")
-
-			err = lotusService.LotusMarket.LotusImportData(deal.DealCid, deal.FilePath)
-			if err != nil { //There should be no output if everything goes well
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "import deal failed", err.Error())
-				continue
-			}
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal imported")
-		default:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal already imported", *onChainStatus, *onChainMessage)
-		}
+		UpdateSwanDealStatus(minerId, dealId, onChainStatus, *onChainMessage, deal, true, aria2AutoDeleteCarFile)
 
 		logs.GetLogger().Info("Sleeping...")
 		time.Sleep(lotusService.ImportIntervalSecond)
@@ -131,51 +92,15 @@ func (lotusService *LotusService) StartScan(swanClient *swan.SwanClient) {
 		logs.GetLogger().Error("no deals returned from lotus")
 		return
 	}
-
+	aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
 	for _, deal := range deals {
-		//logs.GetLogger().Info(GetLog(deal, "current status in swan:"+deal.Status, "current note in swan:"+deal.Note))
-		onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatusFromDeals(lotusDeals, deal.DealCid)
+		minerId, dealId, onChainStatus, onChainMessage, err := lotusService.LotusMarket.LotusGetDealOnChainStatusFromDeals(lotusDeals, deal.DealCid)
 		if err != nil {
 			logs.GetLogger().Error(GetLog(deal, err.Error()))
 			return
 		}
 
-		if utils.IsStrEmpty(onChainStatus) {
-			logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
-			continue
-		}
-		aria2AutoDeleteCarFile := config.GetConfig().Aria2.Aria2AutoDeleteCarFile
-		switch *onChainStatus {
-		case ONCHAIN_DEAL_STATUS_ERROR:
-			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal error when scan", *onChainStatus, *onChainMessage)
-			if aria2AutoDeleteCarFile {
-				msg := fmt.Sprintf("deal(id=%d):%s, %s, %s", deal.Id, *deal.TaskName+":"+deal.DealCid+" has been "+*onChainStatus, "delete the car file", deal.FilePath)
-				logs.GetLogger().Info(msg)
-				DeleteDownloadedFiles(deal.FilePath)
-			}
-		case ONCHAIN_DEAL_STATUS_ACTIVE:
-			UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal has been completed", *onChainStatus, *onChainMessage)
-			if aria2AutoDeleteCarFile {
-				msg := fmt.Sprintf("deal(id=%d):%s, %s, %s", deal.Id, *deal.TaskName+":"+deal.DealCid+" has been "+*onChainStatus, "delete the car file", deal.FilePath)
-				logs.GetLogger().Info(msg)
-				DeleteDownloadedFiles(deal.FilePath)
-			}
-		case ONCHAIN_DEAL_STATUS_AWAITING, ONCHAIN_DEAL_STATUS_SEALING:
-			currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
-			if err != nil {
-				logs.GetLogger().Error(GetLog(deal, err.Error()))
-				return
-			}
-
-			if *currentEpoch > int64(deal.StartEpoch) {
-				UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "sector is proved and active, on chain status bug", *onChainStatus, *onChainMessage)
-			} else {
-				UpdateStatusAndLog(deal, deal.Status, *onChainStatus, *onChainMessage)
-			}
-		default:
-			UpdateStatusAndLog(deal, deal.Status, *onChainStatus, *onChainMessage)
-		}
+		UpdateSwanDealStatus(minerId, dealId, onChainStatus, *onChainMessage, deal, false, aria2AutoDeleteCarFile)
 	}
 }
 
@@ -195,5 +120,89 @@ func DeleteDownloadedFiles(filePath string) {
 				logs.GetLogger().Info("delete file successfully ", " file path ", filePath)
 			}
 		}
+	}
+}
+
+func CorrectDealStatus(startEpoch int, minerId string, dealId uint64, onChainStatus string) (*string, error) {
+	dealInfo, err := lotusService.LotusClient.LotusGetDealById(dealId)
+	if err != nil {
+		logs.GetLogger().Errorf("get market deal info by dealId failed,dealId: %d,error: %s ", dealId, err.Error())
+		return nil, err
+	}
+	if dealInfo.State.SectorStartEpoch > -1 && dealInfo.State.SlashEpoch == -1 && dealInfo.Proposal.Provider == minerId {
+		onChainStatus = "StorageDealActive"
+	}
+
+	currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
+	if err != nil {
+		logs.GetLogger().Error(err)
+		return nil, err
+	}
+	if startEpoch < int(*currentEpoch)+lotusService.ExpectedSealingTime {
+		onChainStatus = "StorageDealError"
+	}
+	return &onChainStatus, nil
+}
+
+func UpdateSwanDealStatus(minerId string, dealId uint64, onChainStatus *string, onChainMessage string, deal *model.OfflineDeal, isImport, aria2AutoDeleteCarFile bool) {
+	if dealId > 0 {
+		status, err := CorrectDealStatus(deal.StartEpoch, minerId, dealId, *onChainStatus)
+		if err != nil {
+			logs.GetLogger().Error(GetLog(deal, err.Error()))
+			return
+		}
+		onChainStatus = status
+	}
+
+	if utils.IsStrEmpty(onChainStatus) {
+		logs.GetLogger().Info(GetLog(deal, "not found the deal on the chain"))
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "not found the deal on the chain")
+		return
+	}
+
+	switch *onChainStatus {
+	case ONCHAIN_DEAL_STATUS_ERROR:
+		if isImport {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal is error before importing", *onChainStatus, onChainMessage)
+		} else {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal error when scan", *onChainStatus, onChainMessage)
+			if aria2AutoDeleteCarFile {
+				logs.GetLogger().Infof("dealId:%d, taskName:%s, dealCid:%s, has been %s, delete the car file, filePath:%s", dealId, *deal.TaskName, deal.DealCid, *onChainStatus, deal.FilePath)
+				DeleteDownloadedFiles(deal.FilePath)
+			}
+		}
+	case ONCHAIN_DEAL_STATUS_ACTIVE:
+		UpdateStatusAndLog(deal, DEAL_STATUS_ACTIVE, "deal has been completed", *onChainStatus, onChainMessage)
+		if aria2AutoDeleteCarFile {
+			logs.GetLogger().Infof("dealId:%d, taskName:%s, dealCid:%s, has been %s, delete the car file, filePath:%s", dealId, *deal.TaskName, deal.DealCid, *onChainStatus, deal.FilePath)
+			DeleteDownloadedFiles(deal.FilePath)
+		}
+	case ONCHAIN_DEAL_STATUS_ACCEPT:
+		UpdateStatusAndLog(deal, deal.Status, "deal will be ready shortly", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_NOTFOUND:
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal not found", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_AWAITING, ONCHAIN_DEAL_STATUS_SEALING:
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal already imported", *onChainStatus, onChainMessage)
+	case ONCHAIN_DEAL_STATUS_WAITTING:
+		currentEpoch, err := lotusService.LotusClient.LotusGetCurrentEpoch()
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return
+		}
+
+		if int64(deal.StartEpoch)-*currentEpoch < int64(lotusService.ExpectedSealingTime) {
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "deal expired before importing", *onChainStatus, onChainMessage)
+			return
+		}
+
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTING, "importing deal")
+		err = lotusService.LotusMarket.LotusImportData(deal.DealCid, deal.FilePath)
+		if err != nil { //There should be no output if everything goes well
+			UpdateStatusAndLog(deal, DEAL_STATUS_IMPORT_FAILED, "import deal failed", err.Error())
+			return
+		}
+		UpdateStatusAndLog(deal, DEAL_STATUS_IMPORTED, "deal imported")
+	default:
+		UpdateStatusAndLog(deal, deal.Status, *onChainStatus, onChainMessage)
 	}
 }


### PR DESCRIPTION
 - Get the deal info by the `dealID` from the lotus API;
 - Correct `StorageDealError` and `StorageDealActive` according to the on-chain deal info;