### PR TITLE
fix: panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,5 @@ sudo systemctl enable aria2c.service           # Set to start Aria2 automaticall
 sudo systemctl restart aria2c.service            # Start Aria2
 
 chmod +x ./${BINARY_NAME}
-./${BINARY_NAME}  daemon             # Run swan provider
 
 


### PR DESCRIPTION
Fix: can not find deal info due to re-init `lotus-miner` DagStore